### PR TITLE
[feature/crawling] Start again review crawling from where it ended the last time

### DIFF
--- a/src/main/java/com/digital_nomad/find_my_office/domain/cafe/entity/Review.java
+++ b/src/main/java/com/digital_nomad/find_my_office/domain/cafe/entity/Review.java
@@ -32,7 +32,7 @@ public class Review {
     @Setter
     private List<ReviewImage> reviewImages = new ArrayList<>();
 
-    @Column(nullable = true, name="review_content")
+    @Column(nullable = true, name="review_content", columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false, name="review_date")

--- a/src/test/java/com/digital_nomad/find_my_office/repository/CafeRepositoryImplTest.java
+++ b/src/test/java/com/digital_nomad/find_my_office/repository/CafeRepositoryImplTest.java
@@ -49,4 +49,12 @@ class CafeRepositoryImplTest {
         byAddressProvinceName.forEach(System.out::println);
     }
 
+    @Test
+    @DisplayName("서울특별시의 크롤링 완료된 업체만 나온다.")
+    void cafeInSeoulNoCrawling() {
+
+        List<Cafe> seoulCafes = cafeRepository.findByAddressProvinceName("서울특별시");
+
+        seoulCafes.forEach(System.out::println);
+    }
 }


### PR DESCRIPTION
## 📌 PR 요약 
- Selenium으로 크롤링 시 이전에 크롤링 끝난 업체 다음 업체부터 크롤링 시작

## 📌 구현 방법
- 크롤링을 위한 카페 리스트를 불러올 때, review_crawling_status가 저장되지 않은 업체만 필터링하여 불러옴
![image](https://github.com/user-attachments/assets/de7116fc-e3b2-45a7-90ba-205aae1e2c3f)

## 🔍 진행해야 할 사항
- 전체 업체 리뷰 크롤링하여 DB에 저장

## ✅ 테스트 결과
- [x] 저장된 데이터가 DB에서 정상적으로 조회됨
